### PR TITLE
fix: gitignore configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,14 @@
 # Project exclude paths
-/target/
+**/target/
+
+# IDEA files
+
+.idea/libraries/**
+.idea/compiler.xml
+.idea/jarRepositories.xml
+.idea/kotlinc.xml
+.idea/vcs.xml
+.idea/misc.xml
+.idea/modules.xml
+
+**/*.iml


### PR DESCRIPTION
I fixed the existing ignore rule for `/target/`, because (at least for me) it does not work (I have Windows OS) and not ignore hundreds of trash files.

I also added some new rules for ignoring trash-files from IDEA, which generates locally with every project build.